### PR TITLE
fixed handling unicode charecters

### DIFF
--- a/src/com/jspconverter/JSPConverterUtil.java
+++ b/src/com/jspconverter/JSPConverterUtil.java
@@ -47,6 +47,7 @@ public class JSPConverterUtil
 			PsiJavaFile psiJavaFile = (PsiJavaFile) psiFile;
 			StringBuilder sb = new StringBuilder();
 
+			sb.append("<%@ page contentType=\"text/html; charset=UTF-8\" %>");
 			sb.append(COMMENT_PREFIX + " Imports " + COMMENT_SUFFIX);
 			sb.append(NEWLINE_PREFIX + NEWLINE_STR);
 


### PR DESCRIPTION
now JSP can print a wider range of characters
.
When i tried to print Tamil and hindi text for my app via the generated jsp they were printed as '?' after configuring the jsp to use UTF-8 it can now print a wider range of characters including tamil and hindi text
.
hope to see this change in intellij plugin update soon